### PR TITLE
feat: add clickable course links and source citations

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Course Materials Assistant</title>
-    <link rel="stylesheet" href="style.css?v=9">
+    <link rel="stylesheet" href="style.css?v=10">
 </head>
 <body>
     <div class="container">
@@ -74,8 +74,25 @@
         </div>
     </div>
 
+    <!-- Course Content Modal -->
+    <div id="courseModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="modalTitle">Course Content</h2>
+                <span class="close" id="modalClose">&times;</span>
+            </div>
+            <div class="modal-body">
+                <div class="modal-links">
+                    <a id="originalCourseLink" href="#" target="_blank" style="display: none;">View Original Course</a>
+                </div>
+                <div class="modal-text">
+                    <pre id="modalContent"></pre>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="script.js?v=9"></script>
+    <script src="script.js?v=10"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -716,3 +716,140 @@ details[open] .suggested-header::before {
         width: 280px;
     }
 }
+
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(4px);
+}
+
+.modal-content {
+    background-color: var(--surface);
+    margin: 2rem auto;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    width: 90%;
+    max-width: 800px;
+    max-height: 90vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow);
+}
+
+.modal-header {
+    background-color: var(--background);
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h2 {
+    color: var(--text-primary);
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.close {
+    color: var(--text-secondary);
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    line-height: 1;
+    transition: color 0.2s ease;
+}
+
+.close:hover,
+.close:focus {
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.modal-links {
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-links a {
+    color: var(--primary-color);
+    text-decoration: none;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    background: rgba(37, 99, 235, 0.1);
+    border: 1px solid var(--primary-color);
+    border-radius: 6px;
+    display: inline-block;
+    transition: all 0.2s ease;
+}
+
+.modal-links a:hover {
+    background: var(--primary-color);
+    color: white;
+}
+
+.modal-text {
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.modal-text pre {
+    background: var(--background);
+    padding: 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+    font-size: 0.875rem;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+/* Clickable course titles and sources */
+.course-title-item.clickable {
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border-radius: 4px;
+    padding: 0.5rem 0.5rem;
+    margin: 0.25rem 0;
+}
+
+.course-title-item.clickable:hover {
+    background: var(--surface-hover);
+    color: var(--primary-color);
+    transform: translateX(2px);
+}
+
+.clickable-source {
+    color: var(--primary-color);
+    cursor: pointer;
+    text-decoration: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    transition: all 0.2s ease;
+    display: inline-block;
+    margin: 0.1rem;
+}
+
+.clickable-source:hover {
+    background: rgba(37, 99, 235, 0.1);
+    text-decoration: underline;
+}


### PR DESCRIPTION
Adds clickable course links and source citations as requested in issue #3.

## Changes:
- Add new API endpoint `/api/course/{filename}` to serve course content
- Make course titles in sidebar clickable to open course viewer
- Make source citations in chat clickable
- Add modal popup to display full course content with external links
- Include link to original course when available in course files

Fixes #3

Generated with [Claude Code](https://claude.ai/code)